### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,13 +6,13 @@ stopStepper	KEYWORD2
 runStepper	KEYWORD2
 turnStepper	KEYWORD2
 
-Low              LITERAL1
-Medium           LITERAL1
-High             LITERAL1
+Low	LITERAL1
+Medium	LITERAL1
+High	LITERAL1
 
-CounterClockwise LITERAL1 
-Clockwise        LITERAL1
+CounterClockwise	LITERAL1 
+Clockwise	LITERAL1
 
-Full             LITERAL1
-Half             LITERAL1
+Full	LITERAL1
+Half	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords